### PR TITLE
fix: harden GitHub Actions against supply chain attacks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -8,7 +8,7 @@ jobs:
   #  steps:
   #    - uses: actions/checkout@v5
 
-  #    - uses: actions/setup-python@v6
+  #    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
   #      with:
   #        cache: pip
 
@@ -21,9 +21,9 @@ jobs:
     name: Lint role
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           cache: pip
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,10 +8,10 @@ jobs:
     name: Publish on Ansible Galaxy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name:
-        uses: robertdebock/galaxy-action@1.2.1
+        uses: robertdebock/galaxy-action@7d89099e09f4385ec4b53eb58c0d120f1ad806dd # 1.2.1
         with:
           git_branch: main
           galaxy_api_key: ${{ secrets.GALAXY_API_KEY }}


### PR DESCRIPTION
## Summary

- Pin all GitHub Actions references to immutable commit SHAs (prevents tag/branch force-push attacks)
- Add Dependabot configuration for automatic GitHub Actions version updates

## Context

On 2026-03-19, `aquasecurity/trivy-action` was compromised via a tag force-push attack that exfiltrated secrets from CI runners. SHA-pinning prevents this class of attack entirely.

The netresearch org now enforces `sha_pinning_required=true` — workflows using tag/branch references will fail.

Ref: https://github.com/netresearch/ofelia/issues/535

## Test plan

- [ ] Verify CI passes with SHA-pinned actions
- [ ] Verify Dependabot creates PRs for action updates